### PR TITLE
fix migrations in diesel_sqlite example code

### DIFF
--- a/examples/databases/src/diesel_sqlite.rs
+++ b/examples/databases/src/diesel_sqlite.rs
@@ -95,11 +95,11 @@ async fn run_migrations(rocket: Rocket<Build>) -> Rocket<Build> {
     // specified directory, initializing the database.
     //diesel_migrations::embed_migrations!("db/diesel/migrations");
 
-    let mut conn = Db::get_one(&rocket).await.expect("database connection");
-    //conn.run(|c| embedded_migrations::run(c)).await.expect("diesel migrations");
+    let db = Db::get_one(&rocket).await.expect("database connection");
+    db.run(|conn| {
+        conn.run_pending_migrations(MIGRATIONS).expect("diesel migrations");
+    }).await;
 
-
-    //conn.run_pending_migrations(MIGRATIONS);
     rocket
 }
 


### PR DESCRIPTION
This fixes the migrations in the diesel_sqlite example code. To test, I built the code, sent a request to create a post, listed the posts, then queried a post. Everything worked as expected.

This is an attempt to advance SergioBenitez/Rocket#2242